### PR TITLE
feat: INSTANCEとCOMPONENT_SETのサポート

### DIFF
--- a/packages/message-types/src/plugin-to-ui-message.ts
+++ b/packages/message-types/src/plugin-to-ui-message.ts
@@ -1,7 +1,7 @@
 export type FrameInfo = {
   id: string;
   name: string;
-  type: "FRAME" | "COMPONENT";
+  type: "FRAME" | "COMPONENT" | "INSTANCE";
   layoutMode: "NONE" | "HORIZONTAL" | "VERTICAL" | "GRID";
   isValid: boolean;
   children?: FrameInfo[];

--- a/packages/plugin/src/utils/frame-selected.ts
+++ b/packages/plugin/src/utils/frame-selected.ts
@@ -2,7 +2,12 @@ import { postMessage } from "./post-message";
 
 export const frameSelected = (): void => {
   const selection = figma.currentPage.selection;
-  if (selection.length === 1 && (selection[0].type === "FRAME" || selection[0].type === "COMPONENT")) {
+  if (
+    selection.length === 1 &&
+    (selection[0].type === "FRAME" ||
+      selection[0].type === "COMPONENT" ||
+      selection[0].type === "COMPONENT_SET")
+  ) {
     postMessage({
       type: "frame-selected",
       frameId: selection[0].id,

--- a/packages/plugin/src/utils/frame-selected.ts
+++ b/packages/plugin/src/utils/frame-selected.ts
@@ -4,9 +4,7 @@ export const frameSelected = (): void => {
   const selection = figma.currentPage.selection;
   if (
     selection.length === 1 &&
-    (selection[0].type === "FRAME" ||
-      selection[0].type === "COMPONENT" ||
-      selection[0].type === "COMPONENT_SET")
+    (selection[0].type === "FRAME" || selection[0].type === "COMPONENT" || selection[0].type === "COMPONENT_SET")
   ) {
     postMessage({
       type: "frame-selected",

--- a/packages/plugin/src/utils/lint-frames.ts
+++ b/packages/plugin/src/utils/lint-frames.ts
@@ -3,14 +3,26 @@ import { FrameInfo } from "@frame-lint/message-types";
 import { loadAllowedPatterns } from "./allowed-pattern";
 import { postMessage } from "./post-message";
 
-const getAllFrames = (node: BaseNode, includeRoot = true): (FrameNode | ComponentNode)[] => {
-  const frames: (FrameNode | ComponentNode)[] = [];
+const getAllFrames = (
+  node: BaseNode,
+  includeRoot = true
+): (FrameNode | ComponentNode | InstanceNode)[] => {
+  const frames: (FrameNode | ComponentNode | InstanceNode)[] = [];
 
-  if ((node.type === "FRAME" || node.type === "COMPONENT") && includeRoot) {
-    frames.push(node as FrameNode | ComponentNode);
+  if (
+    (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "INSTANCE") &&
+    includeRoot
+  ) {
+    frames.push(node as FrameNode | ComponentNode | InstanceNode);
   }
 
-  if (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "PAGE" || node.type === "SECTION") {
+  if (
+    node.type === "FRAME" ||
+    node.type === "COMPONENT" ||
+    node.type === "PAGE" ||
+    node.type === "SECTION" ||
+    node.type === "COMPONENT_SET"
+  ) {
     if ("children" in node) {
       for (const child of node.children) {
         frames.push(...getAllFrames(child));
@@ -29,24 +41,47 @@ const checkFrameName = (name: string, patterns: string[]): boolean => {
   });
 };
 
-const buildFrameHierarchy = (frames: (FrameNode | ComponentNode)[], patterns: string[]): FrameInfo[] => {
+const buildFrameHierarchy = (
+  frames: (FrameNode | ComponentNode | InstanceNode)[],
+  patterns: string[]
+): FrameInfo[] => {
   const frameInfos: FrameInfo[] = [];
   const processedIds = new Set<string>();
 
-  const processFrame = (frame: FrameNode | ComponentNode): FrameInfo | null => {
+  const processFrame = (
+    frame: FrameNode | ComponentNode | InstanceNode
+  ): FrameInfo | null => {
     if (processedIds.has(frame.id)) {
       return null;
     }
     processedIds.add(frame.id);
 
+    if (frame.type === "INSTANCE") {
+      return {
+        id: frame.id,
+        name: frame.name,
+        type: "INSTANCE",
+        layoutMode: "NONE",
+        isValid: true,
+      };
+    }
+
     const isValid =
-      frame.parent?.type === "PAGE" || frame.parent?.type === "SECTION" || checkFrameName(frame.name, patterns);
+      frame.parent?.type === "PAGE" ||
+      frame.parent?.type === "SECTION" ||
+      checkFrameName(frame.name, patterns);
 
     const childFrames: FrameInfo[] = [];
     if ("children" in frame) {
       for (const child of frame.children) {
-        if (child.type === "FRAME" || child.type === "COMPONENT") {
-          const childInfo = processFrame(child as FrameNode | ComponentNode);
+        if (
+          child.type === "FRAME" ||
+          child.type === "COMPONENT" ||
+          child.type === "INSTANCE"
+        ) {
+          const childInfo = processFrame(
+            child as FrameNode | ComponentNode | InstanceNode
+          );
           if (childInfo) {
             childFrames.push(childInfo);
           }
@@ -54,18 +89,14 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode)[], patterns: st
       }
     }
 
-    if (!isValid || childFrames.length > 0) {
-      return {
-        id: frame.id,
-        name: frame.name,
-        type: frame.type as "FRAME" | "COMPONENT",
-        layoutMode: "layoutMode" in frame ? frame.layoutMode : "NONE",
-        isValid: isValid,
-        children: childFrames.length > 0 ? childFrames : undefined,
-      };
-    }
-
-    return null;
+    return {
+      id: frame.id,
+      name: frame.name,
+      type: frame.type as "FRAME" | "COMPONENT",
+      layoutMode: "layoutMode" in frame ? frame.layoutMode : "NONE",
+      isValid: isValid,
+      children: childFrames.length > 0 ? childFrames : undefined,
+    };
   };
 
   for (const frame of frames) {
@@ -79,18 +110,30 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode)[], patterns: st
 };
 
 export const lintFrames = async (selectedFrameId?: string): Promise<void> => {
-  let allFrames: (FrameNode | ComponentNode)[];
+  let allFrames: (FrameNode | ComponentNode | InstanceNode)[];
 
   if (selectedFrameId) {
     const selectedNode = await figma.getNodeByIdAsync(selectedFrameId);
-    if (selectedNode && (selectedNode.type === "FRAME" || selectedNode.type === "COMPONENT")) {
+    if (
+      selectedNode &&
+      (selectedNode.type === "FRAME" ||
+        selectedNode.type === "COMPONENT" ||
+        selectedNode.type === "COMPONENT_SET" ||
+        selectedNode.type === "INSTANCE")
+    ) {
       allFrames = getAllFrames(selectedNode);
     } else {
       allFrames = getAllFrames(figma.currentPage);
     }
   } else {
     const selection = figma.currentPage.selection;
-    if (selection.length === 1 && (selection[0].type === "FRAME" || selection[0].type === "COMPONENT")) {
+    if (
+      selection.length === 1 &&
+      (selection[0].type === "FRAME" ||
+        selection[0].type === "COMPONENT" ||
+        selection[0].type === "COMPONENT_SET" ||
+        selection[0].type === "INSTANCE")
+    ) {
       allFrames = getAllFrames(selection[0]);
     } else {
       allFrames = getAllFrames(figma.currentPage);

--- a/packages/plugin/src/utils/lint-frames.ts
+++ b/packages/plugin/src/utils/lint-frames.ts
@@ -3,16 +3,10 @@ import { FrameInfo } from "@frame-lint/message-types";
 import { loadAllowedPatterns } from "./allowed-pattern";
 import { postMessage } from "./post-message";
 
-const getAllFrames = (
-  node: BaseNode,
-  includeRoot = true
-): (FrameNode | ComponentNode | InstanceNode)[] => {
+const getAllFrames = (node: BaseNode, includeRoot = true): (FrameNode | ComponentNode | InstanceNode)[] => {
   const frames: (FrameNode | ComponentNode | InstanceNode)[] = [];
 
-  if (
-    (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "INSTANCE") &&
-    includeRoot
-  ) {
+  if ((node.type === "FRAME" || node.type === "COMPONENT" || node.type === "INSTANCE") && includeRoot) {
     frames.push(node as FrameNode | ComponentNode | InstanceNode);
   }
 
@@ -41,16 +35,11 @@ const checkFrameName = (name: string, patterns: string[]): boolean => {
   });
 };
 
-const buildFrameHierarchy = (
-  frames: (FrameNode | ComponentNode | InstanceNode)[],
-  patterns: string[]
-): FrameInfo[] => {
+const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | InstanceNode)[], patterns: string[]): FrameInfo[] => {
   const frameInfos: FrameInfo[] = [];
   const processedIds = new Set<string>();
 
-  const processFrame = (
-    frame: FrameNode | ComponentNode | InstanceNode
-  ): FrameInfo | null => {
+  const processFrame = (frame: FrameNode | ComponentNode | InstanceNode): FrameInfo | null => {
     if (processedIds.has(frame.id)) {
       return null;
     }
@@ -67,21 +56,13 @@ const buildFrameHierarchy = (
     }
 
     const isValid =
-      frame.parent?.type === "PAGE" ||
-      frame.parent?.type === "SECTION" ||
-      checkFrameName(frame.name, patterns);
+      frame.parent?.type === "PAGE" || frame.parent?.type === "SECTION" || checkFrameName(frame.name, patterns);
 
     const childFrames: FrameInfo[] = [];
     if ("children" in frame) {
       for (const child of frame.children) {
-        if (
-          child.type === "FRAME" ||
-          child.type === "COMPONENT" ||
-          child.type === "INSTANCE"
-        ) {
-          const childInfo = processFrame(
-            child as FrameNode | ComponentNode | InstanceNode
-          );
+        if (child.type === "FRAME" || child.type === "COMPONENT" || child.type === "INSTANCE") {
+          const childInfo = processFrame(child as FrameNode | ComponentNode | InstanceNode);
           if (childInfo) {
             childFrames.push(childInfo);
           }

--- a/packages/ui/src/components/frame-lint/frame-icon.tsx
+++ b/packages/ui/src/components/frame-lint/frame-icon.tsx
@@ -1,6 +1,6 @@
 import { FrameInfo } from "@frame-lint/message-types";
 import { GoColumns, GoRows } from "react-icons/go";
-import { RxComponent1, RxDashboard, RxFrame } from "react-icons/rx";
+import { RxComponent1, RxComponentInstance, RxDashboard, RxFrame } from "react-icons/rx";
 import { match } from "ts-pattern";
 
 export const FrameIcon = ({ type, layoutMode }: { type: FrameInfo["type"]; layoutMode: FrameInfo["layoutMode"] }) => {
@@ -14,5 +14,6 @@ export const FrameIcon = ({ type, layoutMode }: { type: FrameInfo["type"]; layou
         .exhaustive(),
     )
     .with("COMPONENT", () => <RxComponent1 />)
+    .with("INSTANCE", () => <RxComponentInstance />)
     .exhaustive();
 };


### PR DESCRIPTION
## 変更内容

### INSTANCE対応（`buildFrameHierarchy`）
- `FrameInfo` の `type` フィールドに `"INSTANCE"` を追加
- `getAllFrames` で INSTANCE ノードを収集対象に追加（ただし再帰なし）
- `buildFrameHierarchy` / `processFrame` で INSTANCE を `isValid: true`・子要素なしとして処理
- FRAME/COMPONENT の子要素走査でも INSTANCE を含めるよう対応
- `frame-icon.tsx` に INSTANCE 用アイコンを追加

### COMPONENT_SET対応（Variant付きComponentの選択）
- `frame-selected.ts` の選択判定に `COMPONENT_SET` を追加
  - Variantを持つComponentを選択したときに「Lint Selected」が有効になるよう修正
- `getAllFrames` の traversal 条件に `COMPONENT_SET` を追加
  - COMPONENT_SET の子（各 Variant の COMPONENT）を再帰的に収集
- `lintFrames` の selectedNode / selection 判定に `COMPONENT_SET` を追加

## 動作確認

- [ ] Variantなし FRAME を選択 → Lint Selected が有効になる
- [ ] Variantなし COMPONENT を選択 → Lint Selected が有効になる
- [ ] Variantあり COMPONENT_SET を選択 → Lint Selected が有効になる
- [ ] Lint 実行時に INSTANCE が一覧に表示される（Invalid バッジなし）
- [ ] INSTANCE の子要素は表示されない

Made with [Cursor](https://cursor.com)