### PR TITLE
feat: SLOTノード対応とフレーム階層表示の強化

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@figma/plugin-typings": "*",
+    "@figma/plugin-typings": "catalog:",
     "eslint": "^9.33.0",
     "eslint-plugin-chakra-ui": "^0.12.0",
     "eslint-plugin-import": "^2.32.0",

--- a/packages/message-types/package.json
+++ b/packages/message-types/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "*",
+    "@figma/plugin-typings": "catalog:",
     "tsup": "^8.0.1",
     "typescript": "^5.3.2"
   }

--- a/packages/message-types/src/plugin-to-ui-message.ts
+++ b/packages/message-types/src/plugin-to-ui-message.ts
@@ -1,7 +1,7 @@
 export type FrameInfo = {
   id: string;
   name: string;
-  type: "FRAME" | "COMPONENT" | "INSTANCE";
+  type: "FRAME" | "COMPONENT" | "COMPONENT_SET" | "VARIANT" | "INSTANCE" | "SLOT";
   layoutMode: "NONE" | "HORIZONTAL" | "VERTICAL" | "GRID";
   isValid: boolean;
   children?: FrameInfo[];

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
     "ts-pattern": "catalog:"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "*",
+    "@figma/plugin-typings": "catalog:",
     "tsup": "^8.0.1",
     "typescript": "^5.3.2"
   }

--- a/packages/plugin/src/utils/frame-selected.ts
+++ b/packages/plugin/src/utils/frame-selected.ts
@@ -4,7 +4,7 @@ export const frameSelected = (): void => {
   const selection = figma.currentPage.selection;
   if (
     selection.length === 1 &&
-    (selection[0].type === "FRAME" || selection[0].type === "COMPONENT" || selection[0].type === "COMPONENT_SET")
+    (selection[0].type === "FRAME" || selection[0].type === "COMPONENT" || selection[0].type === "COMPONENT_SET" || selection[0].type === "INSTANCE")
   ) {
     postMessage({
       type: "frame-selected",

--- a/packages/plugin/src/utils/frame-selected.ts
+++ b/packages/plugin/src/utils/frame-selected.ts
@@ -4,7 +4,10 @@ export const frameSelected = (): void => {
   const selection = figma.currentPage.selection;
   if (
     selection.length === 1 &&
-    (selection[0].type === "FRAME" || selection[0].type === "COMPONENT" || selection[0].type === "COMPONENT_SET" || selection[0].type === "INSTANCE")
+    (selection[0].type === "FRAME" ||
+      selection[0].type === "COMPONENT" ||
+      selection[0].type === "COMPONENT_SET" ||
+      selection[0].type === "INSTANCE")
   ) {
     postMessage({
       type: "frame-selected",

--- a/packages/plugin/src/utils/lint-frames.ts
+++ b/packages/plugin/src/utils/lint-frames.ts
@@ -8,20 +8,38 @@ const instanceHasSlotProperty = (node: InstanceNode): boolean => {
   return (Object.keys(props) as (keyof typeof props)[]).some((key) => (props[key].type as string) === "SLOT");
 };
 
-const hasSlotDescendant = (node: BaseNode): boolean => {
-  if ((node.type as string) === "SLOT") return true;
-  if ("children" in node) {
-    for (const child of (node as { children: readonly SceneNode[] }).children) {
-      if (hasSlotDescendant(child)) return true;
+/**
+ * Map<node.id, boolean> でメモ化した hasSlotDescendant を返す。
+ * lintFrames 呼び出しごとに新しいキャッシュを生成することで、
+ * 同一トラバーサル内の重複探索を O(n) に抑える。
+ */
+const makeHasSlotDescendant = (): ((node: BaseNode) => boolean) => {
+  const cache = new Map<string, boolean>();
+  const hasSlotDescendant = (node: BaseNode): boolean => {
+    const hit = cache.get(node.id);
+    if (hit !== undefined) return hit;
+    let result = false;
+    if ((node.type as string) === "SLOT") {
+      result = true;
+    } else if ("children" in node) {
+      for (const child of (node as { children: readonly SceneNode[] }).children) {
+        if (hasSlotDescendant(child)) {
+          result = true;
+          break;
+        }
+      }
     }
-  }
-  return false;
+    cache.set(node.id, result);
+    return result;
+  };
+  return hasSlotDescendant;
 };
 
 // insideInstanceNotSlot: SLOT-containing INSTANCE の SLOT 以外の子孫をトラバース中かどうか。
 // true の場合、FRAME/COMPONENT はフレームリストに追加しない（SLOT と無関係な部分のため）。
 const getAllFrames = (
   node: BaseNode,
+  hasSlotDescendant: (node: BaseNode) => boolean,
   includeRoot = true,
   insideInstanceNotSlot = false,
 ): (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[] => {
@@ -47,14 +65,14 @@ const getAllFrames = (
   ) {
     if ("children" in node) {
       for (const child of node.children) {
-        frames.push(...getAllFrames(child, true, insideInstanceNotSlot));
+        frames.push(...getAllFrames(child, hasSlotDescendant, true, insideInstanceNotSlot));
       }
     }
   } else if ((node.type as string) === "SLOT") {
     // SLOT の中はすべて通常モード（insideInstanceNotSlot=false）
     if ("children" in node) {
       for (const child of (node as { children: readonly SceneNode[] }).children) {
-        frames.push(...getAllFrames(child, true, false));
+        frames.push(...getAllFrames(child, hasSlotDescendant, true, false));
       }
     }
   } else if (node.type === "INSTANCE" && hasSlotDescendant(node)) {
@@ -62,10 +80,10 @@ const getAllFrames = (
       for (const child of node.children) {
         if ((child.type as string) === "SLOT") {
           // SLOT の子要素は通常モードで探索
-          frames.push(...getAllFrames(child, true, false));
+          frames.push(...getAllFrames(child, hasSlotDescendant, true, false));
         } else {
           // SLOT 以外の子要素は FRAME/COMPONENT を追加しないモードで探索
-          frames.push(...getAllFrames(child, true, true));
+          frames.push(...getAllFrames(child, hasSlotDescendant, true, true));
         }
       }
     }
@@ -85,6 +103,7 @@ const checkFrameName = (name: string, patterns: string[]): boolean => {
 const buildFrameHierarchy = (
   frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[],
   patterns: string[],
+  hasSlotDescendant: (node: BaseNode) => boolean,
 ): FrameInfo[] => {
   const frameInfos: FrameInfo[] = [];
   const processedIds = new Set<string>();
@@ -178,6 +197,10 @@ const buildFrameHierarchy = (
 };
 
 export const lintFrames = async (selectedFrameId?: string): Promise<void> => {
+  // lintFrames 呼び出しごとに新しいキャッシュを生成し、
+  // getAllFrames・buildFrameHierarchy で共有することで重複探索を防ぐ
+  const hasSlotDescendant = makeHasSlotDescendant();
+
   let allFrames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[];
 
   if (selectedFrameId) {
@@ -189,9 +212,9 @@ export const lintFrames = async (selectedFrameId?: string): Promise<void> => {
         selectedNode.type === "COMPONENT_SET" ||
         selectedNode.type === "INSTANCE")
     ) {
-      allFrames = getAllFrames(selectedNode);
+      allFrames = getAllFrames(selectedNode, hasSlotDescendant);
     } else {
-      allFrames = getAllFrames(figma.currentPage);
+      allFrames = getAllFrames(figma.currentPage, hasSlotDescendant);
     }
   } else {
     const selection = figma.currentPage.selection;
@@ -202,14 +225,14 @@ export const lintFrames = async (selectedFrameId?: string): Promise<void> => {
         selection[0].type === "COMPONENT_SET" ||
         selection[0].type === "INSTANCE")
     ) {
-      allFrames = getAllFrames(selection[0]);
+      allFrames = getAllFrames(selection[0], hasSlotDescendant);
     } else {
-      allFrames = getAllFrames(figma.currentPage);
+      allFrames = getAllFrames(figma.currentPage, hasSlotDescendant);
     }
   }
 
   const allowedPatterns = await loadAllowedPatterns(true);
-  const frameInfos = buildFrameHierarchy(allFrames, allowedPatterns);
+  const frameInfos = buildFrameHierarchy(allFrames, allowedPatterns, hasSlotDescendant);
 
   postMessage({
     type: "frame-lint-result",

--- a/packages/plugin/src/utils/lint-frames.ts
+++ b/packages/plugin/src/utils/lint-frames.ts
@@ -3,11 +3,38 @@ import { FrameInfo } from "@frame-lint/message-types";
 import { loadAllowedPatterns } from "./allowed-pattern";
 import { postMessage } from "./post-message";
 
-const getAllFrames = (node: BaseNode, includeRoot = true): (FrameNode | ComponentNode | InstanceNode)[] => {
-  const frames: (FrameNode | ComponentNode | InstanceNode)[] = [];
+const instanceHasSlotProperty = (node: InstanceNode): boolean => {
+  const props = node.componentProperties;
+  return (Object.keys(props) as (keyof typeof props)[]).some(
+    (key) => (props[key].type as string) === "SLOT"
+  );
+};
 
-  if ((node.type === "FRAME" || node.type === "COMPONENT" || node.type === "INSTANCE") && includeRoot) {
-    frames.push(node as FrameNode | ComponentNode | InstanceNode);
+const hasSlotDescendant = (node: BaseNode): boolean => {
+  if ((node.type as string) === "SLOT") return true;
+  if ("children" in node) {
+    for (const child of (node as { children: readonly SceneNode[] }).children) {
+      if (hasSlotDescendant(child)) return true;
+    }
+  }
+  return false;
+};
+
+// insideInstanceNotSlot: SLOT-containing INSTANCE の SLOT 以外の子孫をトラバース中かどうか。
+// true の場合、FRAME/COMPONENT はフレームリストに追加しない（SLOT と無関係な部分のため）。
+const getAllFrames = (
+  node: BaseNode,
+  includeRoot = true,
+  insideInstanceNotSlot = false,
+): (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[] => {
+  const frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[] = [];
+
+  if (includeRoot) {
+    if (!insideInstanceNotSlot && (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "COMPONENT_SET")) {
+      frames.push(node as FrameNode | ComponentNode | ComponentSetNode);
+    } else if (node.type === "INSTANCE" && hasSlotDescendant(node)) {
+      frames.push(node as InstanceNode);
+    }
   }
 
   if (
@@ -19,7 +46,26 @@ const getAllFrames = (node: BaseNode, includeRoot = true): (FrameNode | Componen
   ) {
     if ("children" in node) {
       for (const child of node.children) {
-        frames.push(...getAllFrames(child));
+        frames.push(...getAllFrames(child, true, insideInstanceNotSlot));
+      }
+    }
+  } else if ((node.type as string) === "SLOT") {
+    // SLOT の中はすべて通常モード（insideInstanceNotSlot=false）
+    if ("children" in node) {
+      for (const child of (node as { children: readonly SceneNode[] }).children) {
+        frames.push(...getAllFrames(child, true, false));
+      }
+    }
+  } else if (node.type === "INSTANCE" && hasSlotDescendant(node)) {
+    if ("children" in node) {
+      for (const child of node.children) {
+        if ((child.type as string) === "SLOT") {
+          // SLOT の子要素は通常モードで探索
+          frames.push(...getAllFrames(child, true, false));
+        } else {
+          // SLOT 以外の子要素は FRAME/COMPONENT を追加しないモードで探索
+          frames.push(...getAllFrames(child, true, true));
+        }
       }
     }
   }
@@ -35,36 +81,69 @@ const checkFrameName = (name: string, patterns: string[]): boolean => {
   });
 };
 
-const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | InstanceNode)[], patterns: string[]): FrameInfo[] => {
+const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[], patterns: string[]): FrameInfo[] => {
   const frameInfos: FrameInfo[] = [];
   const processedIds = new Set<string>();
 
-  const processFrame = (frame: FrameNode | ComponentNode | InstanceNode): FrameInfo | null => {
+  const processFrame = (frame: FrameNode | ComponentNode | ComponentSetNode | InstanceNode): FrameInfo | null => {
     if (processedIds.has(frame.id)) {
       return null;
     }
     processedIds.add(frame.id);
 
-    if (frame.type === "INSTANCE") {
-      return {
-        id: frame.id,
-        name: frame.name,
-        type: "INSTANCE",
-        layoutMode: "NONE",
-        isValid: true,
-      };
+    if (frame.type === "INSTANCE" && !instanceHasSlotProperty(frame)) {
+      if (!hasSlotDescendant(frame)) {
+        return {
+          id: frame.id,
+          name: frame.name,
+          type: "INSTANCE",
+          layoutMode: "NONE",
+          isValid: true,
+        };
+      }
     }
 
     const isValid =
-      frame.parent?.type === "PAGE" || frame.parent?.type === "SECTION" || checkFrameName(frame.name, patterns);
+      frame.type === "INSTANCE" ||
+      frame.type === "COMPONENT_SET" ||
+      frame.parent?.type === "PAGE" ||
+      frame.parent?.type === "SECTION" ||
+      frame.parent?.type === "COMPONENT_SET" ||
+      checkFrameName(frame.name, patterns);
 
     const childFrames: FrameInfo[] = [];
     if ("children" in frame) {
       for (const child of frame.children) {
-        if (child.type === "FRAME" || child.type === "COMPONENT" || child.type === "INSTANCE") {
-          const childInfo = processFrame(child as FrameNode | ComponentNode | InstanceNode);
-          if (childInfo) {
-            childFrames.push(childInfo);
+        if ((child.type as string) === "SLOT" && "children" in child) {
+          const slotChildren: FrameInfo[] = [];
+          for (const slotChild of (child as { children: readonly SceneNode[] }).children) {
+            if (
+              slotChild.type === "FRAME" ||
+              slotChild.type === "COMPONENT" ||
+              slotChild.type === "INSTANCE"
+            ) {
+              const childInfo = processFrame(slotChild as FrameNode | ComponentNode | InstanceNode);
+              if (childInfo) {
+                slotChildren.push(childInfo);
+              }
+            }
+          }
+          childFrames.push({
+            id: (child as { id: string }).id,
+            name: child.name,
+            type: "SLOT",
+            layoutMode: "NONE",
+            isValid: true,
+            children: slotChildren.length > 0 ? slotChildren : undefined,
+          });
+        } else if (child.type === "FRAME" || child.type === "COMPONENT" || child.type === "COMPONENT_SET" || child.type === "INSTANCE") {
+          // INSTANCE の子要素は SLOT 子孫を持つものだけ処理（SLOT の兄弟であるが SLOT でない要素を除外）
+          // FRAME/COMPONENT/COMPONENT_SET の子要素はすべて処理
+          if (frame.type !== "INSTANCE" || hasSlotDescendant(child)) {
+            const childInfo = processFrame(child as FrameNode | ComponentNode | ComponentSetNode | InstanceNode);
+            if (childInfo) {
+              childFrames.push(childInfo);
+            }
           }
         }
       }
@@ -73,7 +152,10 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | InstanceNode)[
     return {
       id: frame.id,
       name: frame.name,
-      type: frame.type as "FRAME" | "COMPONENT",
+      type:
+        frame.type === "COMPONENT" && frame.parent?.type === "COMPONENT_SET"
+          ? ("VARIANT" as const)
+          : (frame.type as "FRAME" | "COMPONENT" | "COMPONENT_SET" | "INSTANCE"),
       layoutMode: "layoutMode" in frame ? frame.layoutMode : "NONE",
       isValid: isValid,
       children: childFrames.length > 0 ? childFrames : undefined,
@@ -91,7 +173,7 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | InstanceNode)[
 };
 
 export const lintFrames = async (selectedFrameId?: string): Promise<void> => {
-  let allFrames: (FrameNode | ComponentNode | InstanceNode)[];
+  let allFrames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[];
 
   if (selectedFrameId) {
     const selectedNode = await figma.getNodeByIdAsync(selectedFrameId);

--- a/packages/plugin/src/utils/lint-frames.ts
+++ b/packages/plugin/src/utils/lint-frames.ts
@@ -5,9 +5,7 @@ import { postMessage } from "./post-message";
 
 const instanceHasSlotProperty = (node: InstanceNode): boolean => {
   const props = node.componentProperties;
-  return (Object.keys(props) as (keyof typeof props)[]).some(
-    (key) => (props[key].type as string) === "SLOT"
-  );
+  return (Object.keys(props) as (keyof typeof props)[]).some((key) => (props[key].type as string) === "SLOT");
 };
 
 const hasSlotDescendant = (node: BaseNode): boolean => {
@@ -30,7 +28,10 @@ const getAllFrames = (
   const frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[] = [];
 
   if (includeRoot) {
-    if (!insideInstanceNotSlot && (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "COMPONENT_SET")) {
+    if (
+      !insideInstanceNotSlot &&
+      (node.type === "FRAME" || node.type === "COMPONENT" || node.type === "COMPONENT_SET")
+    ) {
       frames.push(node as FrameNode | ComponentNode | ComponentSetNode);
     } else if (node.type === "INSTANCE" && hasSlotDescendant(node)) {
       frames.push(node as InstanceNode);
@@ -81,7 +82,10 @@ const checkFrameName = (name: string, patterns: string[]): boolean => {
   });
 };
 
-const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[], patterns: string[]): FrameInfo[] => {
+const buildFrameHierarchy = (
+  frames: (FrameNode | ComponentNode | ComponentSetNode | InstanceNode)[],
+  patterns: string[],
+): FrameInfo[] => {
   const frameInfos: FrameInfo[] = [];
   const processedIds = new Set<string>();
 
@@ -117,11 +121,7 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | ComponentSetNo
         if ((child.type as string) === "SLOT" && "children" in child) {
           const slotChildren: FrameInfo[] = [];
           for (const slotChild of (child as { children: readonly SceneNode[] }).children) {
-            if (
-              slotChild.type === "FRAME" ||
-              slotChild.type === "COMPONENT" ||
-              slotChild.type === "INSTANCE"
-            ) {
+            if (slotChild.type === "FRAME" || slotChild.type === "COMPONENT" || slotChild.type === "INSTANCE") {
               const childInfo = processFrame(slotChild as FrameNode | ComponentNode | InstanceNode);
               if (childInfo) {
                 slotChildren.push(childInfo);
@@ -136,7 +136,12 @@ const buildFrameHierarchy = (frames: (FrameNode | ComponentNode | ComponentSetNo
             isValid: true,
             children: slotChildren.length > 0 ? slotChildren : undefined,
           });
-        } else if (child.type === "FRAME" || child.type === "COMPONENT" || child.type === "COMPONENT_SET" || child.type === "INSTANCE") {
+        } else if (
+          child.type === "FRAME" ||
+          child.type === "COMPONENT" ||
+          child.type === "COMPONENT_SET" ||
+          child.type === "INSTANCE"
+        ) {
           // INSTANCE の子要素は SLOT 子孫を持つものだけ処理（SLOT の兄弟であるが SLOT でない要素を除外）
           // FRAME/COMPONENT/COMPONENT_SET の子要素はすべて処理
           if (frame.type !== "INSTANCE" || hasSlotDescendant(child)) {

--- a/packages/ui/src/components/frame-lint/frame-icon.tsx
+++ b/packages/ui/src/components/frame-lint/frame-icon.tsx
@@ -1,5 +1,7 @@
 import { FrameInfo } from "@frame-lint/message-types";
 import { GoColumns, GoRows } from "react-icons/go";
+import { LuSquarePlus } from "react-icons/lu";
+import { PiDiamondFill } from "react-icons/pi";
 import { RxComponent1, RxComponentInstance, RxDashboard, RxFrame } from "react-icons/rx";
 import { match } from "ts-pattern";
 
@@ -14,6 +16,9 @@ export const FrameIcon = ({ type, layoutMode }: { type: FrameInfo["type"]; layou
         .exhaustive(),
     )
     .with("COMPONENT", () => <RxComponent1 />)
+    .with("COMPONENT_SET", () => <RxComponent1 />)
+    .with("VARIANT", () => <PiDiamondFill />)
     .with("INSTANCE", () => <RxComponentInstance />)
+    .with("SLOT", () => <LuSquarePlus />)
     .exhaustive();
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@figma/plugin-typings':
+      specifier: 1.123.0
+      version: 1.123.0
     fast-deep-equal:
       specifier: 3.1.3
       version: 3.1.3
@@ -21,8 +24,8 @@ importers:
         specifier: ^9.33.0
         version: 9.33.0
       '@figma/plugin-typings':
-        specifier: '*'
-        version: 1.117.0
+        specifier: 'catalog:'
+        version: 1.123.0
       eslint:
         specifier: ^9.33.0
         version: 9.33.0(jiti@2.5.1)
@@ -60,8 +63,8 @@ importers:
   packages/message-types:
     devDependencies:
       '@figma/plugin-typings':
-        specifier: '*'
-        version: 1.117.0
+        specifier: 'catalog:'
+        version: 1.123.0
       tsup:
         specifier: ^8.0.1
         version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(typescript@5.9.2)
@@ -79,8 +82,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@figma/plugin-typings':
-        specifier: '*'
-        version: 1.117.0
+        specifier: 'catalog:'
+        version: 1.123.0
       tsup:
         specifier: ^8.0.1
         version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(typescript@5.9.2)
@@ -1062,8 +1065,8 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@figma/plugin-typings@1.117.0':
-    resolution: {integrity: sha512-EDirBOeOcS90SQ5SwrJyTiL6iJxG/81U9nzJJkBqdWRHGMfFWAOydbAlcRylgETKwIKRlflL92nNSt+WmnweKA==}
+  '@figma/plugin-typings@1.123.0':
+    resolution: {integrity: sha512-NLv2aQ8R9dP5psDplWpq+pJxRUGsJ1YEYYbBV2oTd03kS+aau7N9XWLjw52s1uVgi8jQ33N001EX3f7vSCztjQ==}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -4109,7 +4112,7 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@figma/plugin-typings@1.117.0': {}
+  '@figma/plugin-typings@1.123.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,6 @@ packages:
   - "packages/*"
 
 catalog:
+  "@figma/plugin-typings": 1.123.0
   fast-deep-equal: 3.1.3
   ts-pattern: 5.8.0


### PR DESCRIPTION
## 概要

Figma の SLOT タイプノードを含む INSTANCE ノードをリント対象に追加し、フレーム階層表示を拡張しました。

## 主な変更点

- **SLOT ノードの検出**: `componentProperties` に `SLOT` タイプを持つ INSTANCE ノードを検出する `instanceHasSlotProperty` 関数を追加
- **ネスト SLOT の探索**: SLOT 子孫を持つ INSTANCE ノードを再帰的に探索する `hasSlotDescendant` 関数を追加
- **SLOT ノードの表示**: SLOT ノードをツリーアイテムとして表示（アイコン: `LuSquarePlus`）
- **COMPONENT_SET のサポート**: COMPONENT_SET を階層に表示（常に `isValid: true`）
- **VARIANT タイプの追加**: COMPONENT_SET の直接の子 COMPONENT に `VARIANT` タイプを導入（アイコン: `PiDiamondFill`）
- **INSTANCE の常時バリッド**: すべての INSTANCE ノードを `isValid: true` に設定
- **Lint Selected の拡張**: INSTANCE 選択時にも「Lint Selected」ボタンを有効化
- **非 SLOT 兄弟の除外**: INSTANCE 内の SLOT と無関係な子要素をリント対象から除外
- **`@figma/plugin-typings` のカタログ化**: バージョンを `1.123.0` に統一し pnpm catalog で管理

## アイコン対応表

| タイプ | アイコン |
|--------|---------|
| `FRAME` | `RxFrame` / `GoRows` / `GoColumns` |
| `COMPONENT` | `RxComponent1` |
| `COMPONENT_SET` | `RxComponent1` |
| `VARIANT` | `PiDiamondFill` |
| `INSTANCE` | `RxComponentInstance` |
| `SLOT` | `LuSquarePlus` |


Made with [Cursor](https://cursor.com)